### PR TITLE
Add second line of subscription messaging 

### DIFF
--- a/interactive-opinion/src/templates/main.html
+++ b/interactive-opinion/src/templates/main.html
@@ -21,7 +21,7 @@
                     <div class="email-signup email-signup__lozenge" data-component="opinion-email-interactive">
                       <iframe src="https://www.theguardian.com/email/form/plaintone/3811" height="60px" width="100%" scrolling="no" frameborder="0" seamless
                       class="iframed--overflow-hidden js-email-sub__iframe js-email-sub__iframe--article"
-                      data-form-success-desc="">
+                      data-form-success-desc="Your next email is on its way.">
                       </iframe>
 
                         <div class="email-signup__aside-text">


### PR DESCRIPTION
## What does this change?

When a user signs up the message will now read:

Thank you for subscribing
Your next email is on its way.

NB - To change the first line, just add “data-form-success-headline”

## Screenshots

## Request for comment

<!-- mention someone here to review your changes -->
