### PR TITLE
Update bookmarks page for dcr

### DIFF
--- a/bookmarks/atoms/default/client/css/main.scss
+++ b/bookmarks/atoms/default/client/css/main.scss
@@ -72,7 +72,7 @@ $email-secondary-colour: #ab0613;
     height: 220px;
     width: 100%;
     position: relative;
-    z-index: 10;
+    z-index: 4;
 
     @include mq(tablet) {
       height: 360px;
@@ -90,22 +90,8 @@ $email-secondary-colour: #ab0613;
     background-position: 50% 0;
     background-repeat: no-repeat;
     margin: auto;
-    z-index: 5;
+    z-index: 3;
   }
-
-  // .inline-custom__png {
-  //   display: block;
-  //   overflow: hidden;
-  //   background-image: url("<%= path %>/header/test-2.png");
-  //   position: absolute;
-  //   height: 100%;
-  //   width: 100%;
-  //   background-size: auto 100%;
-  //   background-position: 50% 0;
-  //   background-repeat: no-repeat;
-  //   margin: auto;
-  //   z-index: 10;
-  // }
 
   .inline-svg {
     overflow: hidden;
@@ -115,7 +101,7 @@ $email-secondary-colour: #ab0613;
     left: 50%;
     transform: translateX(-50%);
     margin: auto;
-    z-index: 5;
+    z-index: 3;
     svg {
       height: 220px;
     }
@@ -275,7 +261,7 @@ $email-secondary-colour: #ab0613;
       }
     }
 
-    &__aside-text__frequency {
+    __aside-text__frequency {
       color: $email-text-colour;
       float: right;
       font-weight: bold;

--- a/bookmarks/atoms/default/client/css/main.scss
+++ b/bookmarks/atoms/default/client/css/main.scss
@@ -20,16 +20,16 @@ $comment-support-4: #e6711b;
 
 $gs-baseline: 12px;
 
-$background-colour: $white;
-$text-colour: #000000;
-$secondary-colour: #c70000;
+$background-colour: $review-support-1;
+$text-colour: $white;
+$secondary-colour: $comment-support-3;
+
+$email-background-colour: $white;
+$email-text-colour: $neutral-1;
+$email-secondary-colour: #ab0613;
 
 .interactive-wrapper {
   overflow-x: hidden;
-
-  .email-signup__lozenge {
-    margin: 0px -4px;
-  }
 
   .is-hidden {
     display: none;
@@ -43,23 +43,6 @@ $secondary-colour: #c70000;
   .interactive-atom {
     margin: 0 !important;
     overflow-x: hidden !important;
-  }
-
-  .email-sub__form * {
-    -webkit-box-sizing: border-box;
-    -moz-box-sizing: border-box;
-    box-sizing: border-box;
-  }
-
-  .email-sub__form {
-    font-size: 0.875rem;
-    line-height: 1.25rem;
-    font-family: "Guardian Text Sans Web", "Helvetica Neue", Helvetica, Arial,
-      "Lucida Grande", sans-serif;
-  }
-
-  .email-sub__message__headline {
-    color: white;
   }
 
   .inline-envelope {
@@ -269,49 +252,17 @@ $secondary-colour: #c70000;
 
   .custom-email {
     margin-top: $gs-baseline * 2;
-
-    .email-sub__lozenge {
-      border: 0.0625rem solid $background-colour;
-      border-radius: 100px;
-      float: left;
-      width: 70%;
-      height: 3em;
-      margin-bottom: $gs-baseline;
-
-      &:hover,
-      &:focus,
-      &:active {
-        border-color: darken($secondary-colour, 10%);
-      }
-
-      @include mq($until: tablet) {
-        width: 100%;
-      }
-    }
-
-    .email-sub__lozenge--input {
-      padding: 0.667em 1.25em;
-    }
-
-    .email-sub__lozenge--submit {
-      color: $neutral-7;
-      width: 25%;
-      margin: 0px 0px $gs-baseline 3%;
-      background-color: inherit;
-
-      @include mq($until: tablet) {
-        width: 100%;
-        margin-left: 0;
-      }
-    }
+    background-color: $email-background-colour;
+    padding: 8px 6px;
+    border-radius: 8px;
 
     .inline-clock {
-      fill: $text-colour;
+      fill: $email-text-colour;
     }
 
     .email-signup__aside-text {
       @include fs-textSans(2);
-      color: $secondary-colour;
+      color: $email-secondary-colour;
       width: 64%;
       margin: 0% 4px;
 
@@ -321,7 +272,7 @@ $secondary-colour: #c70000;
     }
 
     .email-signup__aside-text__frequency {
-      color: $text-colour;
+      color: $email-text-colour;
       float: right;
       font-weight: bold;
     }
@@ -407,7 +358,7 @@ $secondary-colour: #c70000;
           }
 
           path {
-            fill: $white;
+            fill: $background-colour;
           }
         }
       }

--- a/bookmarks/atoms/default/client/css/main.scss
+++ b/bookmarks/atoms/default/client/css/main.scss
@@ -256,6 +256,10 @@ $email-secondary-colour: #ab0613;
     padding: 8px 6px;
     border-radius: 8px;
 
+    iframe {
+      min-height: 90px;
+    }
+
     .inline-clock {
       fill: $email-text-colour;
     }
@@ -276,10 +280,6 @@ $email-secondary-colour: #ab0613;
       float: right;
       font-weight: bold;
     }
-  }
-
-  .email-signup-header {
-    color: $text-colour;
   }
 
   .email-signup-header__heading {
@@ -325,6 +325,8 @@ $email-secondary-colour: #ab0613;
   }
 
   .email-signup-header {
+    color: $text-colour;
+
     a {
       display: inline-block;
       text-decoration: none !important;

--- a/bookmarks/atoms/default/client/css/main.scss
+++ b/bookmarks/atoms/default/client/css/main.scss
@@ -24,409 +24,414 @@ $background-colour: $white;
 $text-colour: #000000;
 $secondary-colour: #c70000;
 
-.email-signup__lozenge {
-  margin: 0px -4px;
-}
-
-.is-hidden {
-  display: none;
-}
-
-.is-immersive {
-  background-color: $background-colour;
-}
-
-.element-atom,
-.interactive-atom {
-  margin: 0 !important;
-  overflow-x: hidden !important;
-}
-
-.email-sub__form * {
-  -webkit-box-sizing: border-box;
-  -moz-box-sizing: border-box;
-  box-sizing: border-box;
-}
-
-.email-sub__form {
-  font-size: 0.875rem;
-  line-height: 1.25rem;
-  font-family: "Guardian Text Sans Web", "Helvetica Neue", Helvetica, Arial,
-    "Lucida Grande", sans-serif;
-}
-
-.email-sub__message__headline {
-  color: white;
-}
-
-.inline-envelope {
-  svg {
-    fill: black;
+.interactive-wrapper {
+  .email-signup__lozenge {
+    margin: 0px -4px;
   }
-}
 
-.gs-container {
-  box-sizing: border-box;
-  padding: 0 8px;
-
-  &.l-header__inner {
-    padding: 0;
+  .is-hidden {
+    display: none;
   }
-}
 
-.content {
-  padding-bottom: $gs-baseline * 4;
-}
-
-.illustration-container {
-  -webkit-transform: translate3d(0, 0, 0);
-  transform: translate3d(0, 0, 0);
-  background-color: $illustration-bg;
-  min-height: 10rem;
-  height: 220px;
-  width: 100%;
-  position: relative;
-  z-index: 10;
-
-  @include mq(tablet) {
-    height: 360px;
+  .is-immersive {
+    background-color: $background-colour;
   }
-}
 
-.inline-custom__png {
-  display: block;
-  overflow: hidden;
-  background-image: url("https://uploads.guim.co.uk/2020/06/11/bookmarks-background.svg");
-  position: absolute;
-  height: 100%;
-  width: 100%;
-  background-size: auto 100%;
-  background-position: 50% 0;
-  background-repeat: no-repeat;
-  margin: auto;
-  z-index: 5;
-}
-
-// .inline-custom__png {
-//   display: block;
-//   overflow: hidden;
-//   background-image: url("<%= path %>/header/test-2.png");
-//   position: absolute;
-//   height: 100%;
-//   width: 100%;
-//   background-size: auto 100%;
-//   background-position: 50% 0;
-//   background-repeat: no-repeat;
-//   margin: auto;
-//   z-index: 10;
-// }
-
-.inline-svg {
-  overflow: hidden;
-  position: absolute;
-  height: 100%;
-  width: auto;
-  left: 50%;
-  transform: translateX(-50%);
-  margin: auto;
-  z-index: 5;
-  svg {
-    height: 220px;
+  .element-atom,
+  .interactive-atom {
+    margin: 0 !important;
+    overflow-x: hidden !important;
   }
-  @include mq(tablet) {
+
+  .email-sub__form * {
+    -webkit-box-sizing: border-box;
+    -moz-box-sizing: border-box;
+    box-sizing: border-box;
+  }
+
+  .email-sub__form {
+    font-size: 0.875rem;
+    line-height: 1.25rem;
+    font-family: "Guardian Text Sans Web", "Helvetica Neue", Helvetica, Arial,
+      "Lucida Grande", sans-serif;
+  }
+
+  .email-sub__message__headline {
+    color: white;
+  }
+
+  .inline-envelope {
     svg {
+      fill: black;
+    }
+  }
+
+  .gs-container {
+    box-sizing: border-box;
+    padding: 0 8px;
+
+    &.l-header__inner {
+      padding: 0;
+    }
+  }
+
+  .content {
+    padding-bottom: $gs-baseline * 4;
+  }
+
+  .illustration-container {
+    -webkit-transform: translate3d(0, 0, 0);
+    transform: translate3d(0, 0, 0);
+    background-color: $illustration-bg;
+    min-height: 10rem;
+    height: 220px;
+    width: 100%;
+    position: relative;
+    z-index: 10;
+
+    @include mq(tablet) {
       height: 360px;
     }
   }
-}
 
-#Rocket {
-  transform-origin: center center;
-  animation-name: rotate-rocket;
-  animation-duration: 20s;
-  animation-timing-function: linear;
-  animation-iteration-count: infinite;
-}
+  .inline-custom__png {
+    display: block;
+    overflow: hidden;
+    background-image: url("https://uploads.guim.co.uk/2020/06/11/bookmarks-background.svg");
+    position: absolute;
+    height: 100%;
+    width: 100%;
+    background-size: auto 100%;
+    background-position: 50% 0;
+    background-repeat: no-repeat;
+    margin: auto;
+    z-index: 5;
+  }
 
-@keyframes rotate-rocket {
-  20% {
-    transform: translate(-9px, -13px) rotate(-8deg);
-  }
-  40% {
-    transform: translate(-4px, -5px) rotate(4deg);
-  }
-  60% {
-    transform: translate(-0px, -0px) rotate(-12deg);
-  }
-  80% {
-    transform: translate(-12px, -6px) rotate(-12deg);
-  }
-  0%,
-  100% {
-    transform: translate(0, 0) rotate(0deg);
-  }
-}
+  // .inline-custom__png {
+  //   display: block;
+  //   overflow: hidden;
+  //   background-image: url("<%= path %>/header/test-2.png");
+  //   position: absolute;
+  //   height: 100%;
+  //   width: 100%;
+  //   background-size: auto 100%;
+  //   background-position: 50% 0;
+  //   background-repeat: no-repeat;
+  //   margin: auto;
+  //   z-index: 10;
+  // }
 
-#Burner {
-  animation-name: o-change;
-  animation-duration: 6s;
-  animation-timing-function: linear;
-  animation-iteration-count: infinite;
-}
-
-@keyframes o-change {
-  0% {
-    opacity: 0;
-  }
-  20% {
-    opacity: 1;
-  }
-  80% {
-    opacity: 1;
-  }
-  90% {
-    opacity: 0;
-  }
-  100% {
-    opacity: 0;
-  }
-}
-
-#shooting-star-2 {
-  animation-name: moving-star-2;
-  animation-duration: 5s;
-  animation-timing-function: ease-in-out;
-  animation-iteration-count: infinite;
-}
-
-@keyframes moving-star-2 {
-  0% {
-    opacity: 0;
-    transform: translate(-300px, 200px);
-  }
-  5% {
-    opacity: 1;
-  }
-  15% {
-    opacity: 1;
-  }
-  20% {
-    transform: translate(300px, 40px);
-    opacity: 0;
-  }
-  100% {
-    transform: translate(300px, 40px);
-    opacity: 0;
-  }
-}
-
-#shooting-star-4 {
-  animation-name: moving-star-4;
-  animation-delay: 2s;
-  animation-duration: 5s;
-  animation-timing-function: ease-in-out;
-  animation-iteration-count: infinite;
-}
-
-@keyframes moving-star-4 {
-  0% {
-    opacity: 0;
-    transform: translate(300px, -80px);
-  }
-  5% {
-    opacity: 1;
-  }
-  15% {
-    opacity: 1;
-  }
-  20% {
-    transform: translate(-120px, 240px);
-    opacity: 0;
-  }
-  100% {
-    transform: translate(-120px, 240px);
-    opacity: 0;
-  }
-}
-
-.email-signup {
-  background-color: $background-colour;
-  min-width: 16em;
-}
-
-.main__column--horizontal-bar:before {
-  content: "";
-  display: block;
-  border-bottom: 2px solid $background-colour;
-}
-
-.email-signup-main {
-  background-color: $background-colour;
-}
-
-.custom-email {
-  margin-top: $gs-baseline * 2;
-
-  .email-sub__lozenge {
-    border: 0.0625rem solid $background-colour;
-    border-radius: 100px;
-    float: left;
-    width: 70%;
-    height: 3em;
-    margin-bottom: $gs-baseline;
-
-    &:hover,
-    &:focus,
-    &:active {
-      border-color: darken($secondary-colour, 10%);
+  .inline-svg {
+    overflow: hidden;
+    position: absolute;
+    height: 100%;
+    width: auto;
+    left: 50%;
+    transform: translateX(-50%);
+    margin: auto;
+    z-index: 5;
+    svg {
+      height: 220px;
     }
-
-    @include mq($until: tablet) {
-      width: 100%;
+    @include mq(tablet) {
+      svg {
+        height: 360px;
+      }
     }
   }
 
-  .email-sub__lozenge--input {
-    padding: 0.667em 1.25em;
+  #Rocket {
+    transform-origin: center center;
+    animation-name: rotate-rocket;
+    animation-duration: 20s;
+    animation-timing-function: linear;
+    animation-iteration-count: infinite;
   }
 
-  .email-sub__lozenge--submit {
-    color: $neutral-7;
-    width: 25%;
-    margin: 0px 0px $gs-baseline 3%;
-    background-color: inherit;
-
-    @include mq($until: tablet) {
-      width: 100%;
-      margin-left: 0;
+  @keyframes rotate-rocket {
+    20% {
+      transform: translate(-9px, -13px) rotate(-8deg);
+    }
+    40% {
+      transform: translate(-4px, -5px) rotate(4deg);
+    }
+    60% {
+      transform: translate(-0px, -0px) rotate(-12deg);
+    }
+    80% {
+      transform: translate(-12px, -6px) rotate(-12deg);
+    }
+    0%,
+    100% {
+      transform: translate(0, 0) rotate(0deg);
     }
   }
 
-  .inline-clock {
-    fill: $text-colour;
+  #Burner {
+    animation-name: o-change;
+    animation-duration: 6s;
+    animation-timing-function: linear;
+    animation-iteration-count: infinite;
   }
 
-  .email-signup__aside-text {
-    @include fs-textSans(2);
-    color: $secondary-colour;
-    width: 64%;
-    margin: 0% 4px;
-
-    @include mq($until: tablet) {
-      width: 97%;
+  @keyframes o-change {
+    0% {
+      opacity: 0;
+    }
+    20% {
+      opacity: 1;
+    }
+    80% {
+      opacity: 1;
+    }
+    90% {
+      opacity: 0;
+    }
+    100% {
+      opacity: 0;
     }
   }
 
-  .email-signup__aside-text__frequency {
-    color: $text-colour;
-    float: right;
-    font-weight: bold;
+  #shooting-star-2 {
+    animation-name: moving-star-2;
+    animation-duration: 5s;
+    animation-timing-function: ease-in-out;
+    animation-iteration-count: infinite;
   }
-}
 
-.email-signup-header {
-  color: $text-colour;
-}
+  @keyframes moving-star-2 {
+    0% {
+      opacity: 0;
+      transform: translate(-300px, 200px);
+    }
+    5% {
+      opacity: 1;
+    }
+    15% {
+      opacity: 1;
+    }
+    20% {
+      transform: translate(300px, 40px);
+      opacity: 0;
+    }
+    100% {
+      transform: translate(300px, 40px);
+      opacity: 0;
+    }
+  }
 
-.email-signup-header__heading {
-  display: inline-block;
-  padding-top: $gs-baseline / 2;
+  #shooting-star-4 {
+    animation-name: moving-star-4;
+    animation-delay: 2s;
+    animation-duration: 5s;
+    animation-timing-function: ease-in-out;
+    animation-iteration-count: infinite;
+  }
 
-  svg {
-    height: 30px;
-    width: 159px;
+  @keyframes moving-star-4 {
+    0% {
+      opacity: 0;
+      transform: translate(300px, -80px);
+    }
+    5% {
+      opacity: 1;
+    }
+    15% {
+      opacity: 1;
+    }
+    20% {
+      transform: translate(-120px, 240px);
+      opacity: 0;
+    }
+    100% {
+      transform: translate(-120px, 240px);
+      opacity: 0;
+    }
+  }
 
-    path {
+  .email-signup {
+    background-color: $background-colour;
+    min-width: 16em;
+  }
+
+  .main__column--horizontal-bar:before {
+    content: "";
+    display: block;
+    border-bottom: 2px solid $background-colour;
+  }
+
+  .email-signup-main {
+    background-color: $background-colour;
+  }
+
+  .custom-email {
+    margin-top: $gs-baseline * 2;
+
+    .email-sub__lozenge {
+      border: 0.0625rem solid $background-colour;
+      border-radius: 100px;
+      float: left;
+      width: 70%;
+      height: 3em;
+      margin-bottom: $gs-baseline;
+
+      &:hover,
+      &:focus,
+      &:active {
+        border-color: darken($secondary-colour, 10%);
+      }
+
+      @include mq($until: tablet) {
+        width: 100%;
+      }
+    }
+
+    .email-sub__lozenge--input {
+      padding: 0.667em 1.25em;
+    }
+
+    .email-sub__lozenge--submit {
+      color: $neutral-7;
+      width: 25%;
+      margin: 0px 0px $gs-baseline 3%;
+      background-color: inherit;
+
+      @include mq($until: tablet) {
+        width: 100%;
+        margin-left: 0;
+      }
+    }
+
+    .inline-clock {
       fill: $text-colour;
     }
 
-    @include mq($from: tablet) {
-      height: 39px;
-      width: 206px;
-    }
-  }
-}
+    .email-signup__aside-text {
+      @include fs-textSans(2);
+      color: $secondary-colour;
+      width: 64%;
+      margin: 0% 4px;
 
-.email-signup-header__intro {
-  @include fs-header(2);
-  margin: 0;
-  line-height: 0;
-  padding-top: $gs-baseline / 2;
-  padding-bottom: $gs-baseline;
-
-  @include mq($from: tablet) {
-    @include fs-header(3);
-    line-height: 0;
-  }
-}
-
-.email-signup-header__text {
-  @include fs-bodyCopy(2);
-  margin-top: $gs-baseline / 2;
-
-  @include mq($from: tablet) {
-    @include fs-bodyCopy(3);
-    margin-top: $gs-baseline;
-  }
-}
-
-.email-signup-header {
-  a {
-    display: inline-block;
-    text-decoration: none !important;
-    color: $secondary-colour;
-    &:hover {
-      color: darken($secondary-colour, 10%);
-    }
-  }
-
-  .link-with-arrow {
-    .link-with-arrow__arrow {
-      vertical-align: text-bottom;
-      margin-bottom: 2px;
-      display: inline-block;
-
-      circle {
-        stroke: $secondary-colour;
-        fill: unset;
+      @include mq($until: tablet) {
+        width: 97%;
       }
+    }
+
+    .email-signup__aside-text__frequency {
+      color: $text-colour;
+      float: right;
+      font-weight: bold;
+    }
+  }
+
+  .email-signup-header {
+    color: $text-colour;
+  }
+
+  .email-signup-header__heading {
+    display: inline-block;
+    padding-top: $gs-baseline / 2;
+
+    svg {
+      height: 30px;
+      width: 159px;
 
       path {
-        fill: $secondary-colour;
+        fill: $text-colour;
+      }
+
+      @include mq($from: tablet) {
+        height: 39px;
+        width: 206px;
+      }
+    }
+  }
+
+  .email-signup-header__intro {
+    @include fs-header(2);
+    margin: 0;
+    line-height: 0;
+    padding-top: $gs-baseline / 2;
+    padding-bottom: $gs-baseline;
+
+    @include mq($from: tablet) {
+      @include fs-header(3);
+      line-height: 0;
+    }
+  }
+
+  .email-signup-header__text {
+    @include fs-bodyCopy(2);
+    margin-top: $gs-baseline / 2;
+
+    @include mq($from: tablet) {
+      @include fs-bodyCopy(3);
+      margin-top: $gs-baseline;
+    }
+  }
+
+  .email-signup-header {
+    a {
+      display: inline-block;
+      text-decoration: none !important;
+      color: $secondary-colour;
+      &:hover {
+        color: darken($secondary-colour, 10%);
       }
     }
 
-    &:hover {
+    .link-with-arrow {
       .link-with-arrow__arrow {
+        vertical-align: text-bottom;
+        margin-bottom: 2px;
+        display: inline-block;
+
         circle {
-          fill: darken($secondary-colour, 10%);
-          stroke: unset;
+          stroke: $secondary-colour;
+          fill: unset;
         }
 
         path {
-          fill: $white;
+          fill: $secondary-colour;
+        }
+      }
+
+      &:hover {
+        .link-with-arrow__arrow {
+          circle {
+            fill: darken($secondary-colour, 10%);
+            stroke: unset;
+          }
+
+          path {
+            fill: $white;
+          }
         }
       }
     }
   }
 }
-
 // This is a hack so that the email box can be viewed on Android devices - Frank
-.email-signup-sample {
-  .android & {
-    height: 300px;
+.android {
+  .interactive-wrapper {
+    .email-signup-sample {
+      height: 300px;
+    }
   }
 }
 
 .android,
 .ios {
-  .inline-svg {
-    display: none;
-  }
-  .u-h {
-    display: none;
-  }
-  .inline-custom__png {
-    display: block;
+  .interactive-wrapper {
+    .inline-svg {
+      display: none;
+    }
+    .u-h {
+      display: none;
+    }
+    .inline-custom__png {
+      display: block;
+    }
   }
 }

--- a/bookmarks/atoms/default/client/css/main.scss
+++ b/bookmarks/atoms/default/client/css/main.scss
@@ -264,7 +264,7 @@ $email-secondary-colour: #ab0613;
       fill: $email-text-colour;
     }
 
-    .email-signup__aside-text {
+    &__aside-text {
       @include fs-textSans(2);
       color: $email-secondary-colour;
       width: 64%;
@@ -275,59 +275,59 @@ $email-secondary-colour: #ab0613;
       }
     }
 
-    .email-signup__aside-text__frequency {
+    &__aside-text__frequency {
       color: $email-text-colour;
       float: right;
       font-weight: bold;
     }
   }
 
-  .email-signup-header__heading {
-    display: inline-block;
-    padding-top: $gs-baseline / 2;
-
-    svg {
-      height: 30px;
-      width: 159px;
-
-      path {
-        fill: $text-colour;
-      }
-
-      @include mq($from: tablet) {
-        height: 39px;
-        width: 206px;
-      }
-    }
-  }
-
-  .email-signup-header__intro {
-    @include fs-header(2);
-    margin: 0;
-    line-height: 0;
-    padding-top: $gs-baseline / 2;
-    padding-bottom: $gs-baseline;
-
-    @include mq($from: tablet) {
-      @include fs-header(3);
-      line-height: 0;
-    }
-  }
-
-  .email-signup-header__text {
-    @include fs-bodyCopy(2);
-    margin-top: $gs-baseline / 2;
-
-    @include mq($from: tablet) {
-      @include fs-bodyCopy(3);
-      margin-top: $gs-baseline;
-    }
-  }
-
   .email-signup-header {
     color: $text-colour;
 
-    a {
+    &__heading {
+      display: inline-block;
+      padding-top: $gs-baseline / 2;
+  
+      svg {
+        height: 30px;
+        width: 159px;
+  
+        path {
+          fill: $text-colour;
+        }
+  
+        @include mq($from: tablet) {
+          height: 39px;
+          width: 206px;
+        }
+      }
+    }
+  
+    &__intro {
+      @include fs-header(2);
+      margin: 0;
+      line-height: 0;
+      padding-top: $gs-baseline / 2;
+      padding-bottom: $gs-baseline;
+  
+      @include mq($from: tablet) {
+        @include fs-header(3);
+        line-height: 0;
+      }
+    }
+  
+    &__text {
+      @include fs-bodyCopy(2);
+      margin-top: $gs-baseline / 2;
+  
+      @include mq($from: tablet) {
+        @include fs-bodyCopy(3);
+        margin-top: $gs-baseline;
+      }
+    }
+
+    &__link {
       display: inline-block;
       text-decoration: none !important;
       color: $secondary-colour;
@@ -364,14 +364,6 @@ $email-secondary-colour: #ab0613;
           }
         }
       }
-    }
-  }
-}
-// This is a hack so that the email box can be viewed on Android devices - Frank
-.android {
-  .interactive-wrapper {
-    .email-signup-sample {
-      height: 300px;
     }
   }
 }

--- a/bookmarks/atoms/default/client/css/main.scss
+++ b/bookmarks/atoms/default/client/css/main.scss
@@ -25,6 +25,8 @@ $text-colour: #000000;
 $secondary-colour: #c70000;
 
 .interactive-wrapper {
+  overflow-x: hidden;
+
   .email-signup__lozenge {
     margin: 0px -4px;
   }
@@ -425,9 +427,6 @@ $secondary-colour: #c70000;
 .ios {
   .interactive-wrapper {
     .inline-svg {
-      display: none;
-    }
-    .u-h {
       display: none;
     }
     .inline-custom__png {

--- a/bookmarks/atoms/default/client/css/main.scss
+++ b/bookmarks/atoms/default/client/css/main.scss
@@ -261,7 +261,7 @@ $email-secondary-colour: #ab0613;
       }
     }
 
-    __aside-text__frequency {
+    &__aside-text__frequency {
       color: $email-text-colour;
       float: right;
       font-weight: bold;

--- a/bookmarks/atoms/default/server/templates/main.html
+++ b/bookmarks/atoms/default/server/templates/main.html
@@ -292,7 +292,7 @@
         <div class="custom-email">
             <iframe
               src="https://www.theguardian.com/email/form/plaintone/3039"
-              height="60px"
+              height="95px"
               width="100%"
               scrolling="no"
               frameborder="0"
@@ -305,7 +305,7 @@
             <div class="email-signup__aside-text">
               <span>No spam ever. Unsubscribe in one click.</span>
               <span class="email-signup__aside-text__frequency">
-                <span class="inline-clock inline-icon">
+                <span class="inline-clock inline-icon" aria-label="frequency" role="img">
                   <svg width="11" height="11" viewBox="0 0 11 11">
                     <path
                       d="M5.4 0c-3 0-5.4 2.4-5.4 5.4s2.4 5.4 5.4 5.4 5.4-2.4 5.4-5.4-2.4-5.4-5.4-5.4zm3 6.8h-3.7v-5.1h.7l.6 3.7 2.4.6v.8z"

--- a/bookmarks/atoms/default/server/templates/main.html
+++ b/bookmarks/atoms/default/server/templates/main.html
@@ -1,5 +1,9 @@
 <div class="interactive-wrapper">
-  <div class="illustration-container" role="img" aria-describedby="bookmarks-interactive-illustration-description">
+  <aside
+    class="illustration-container"
+    role="img"
+    aria-describedby="bookmarks-interactive-illustration-description"
+  >
     <div class="inline-custom__png"></div>
     <div class="inline-svg">
       <svg
@@ -9,7 +13,11 @@
         height="480"
         viewBox="0 0 3004 480"
       >
-      <desc id="bookmarks-interactive-illustration-description">A person reading on a comfortable chair while the book transports their imagination to a distant planet populated with various fictional characters.</desc>
+        <desc id="bookmarks-interactive-illustration-description">
+          A person reading on a comfortable chair while the book transports
+          their imagination to a distant planet populated with various fictional
+          characters.
+        </desc>
         <g id="Shooting_Stars">
           <g id="shooting-star-4">
             <linearGradient
@@ -244,9 +252,9 @@
         </g>
       </svg>
     </div>
-  </div>
+  </aside>
 
-  <div class="content email-signup-main">
+  <article class="content email-signup-main">
     <div class="gs-container">
       <div class="content__main-column main__column--horizontal-bar">
         <section class="email-signup-header">
@@ -277,57 +285,64 @@
           <p class="email-signup-header__text">
             Kick back and relax on a Sunday with our weekly email full of
             literary delights.<a
-              class="email-signup-link link-with-arrow"
+              class="email-signup-header__link link-with-arrow"
               target="_blank"
               class="js-email-example"
               href="https://www.theguardian.com/email/bookmarks"
               >View the latest email
-              <svg class="link-with-arrow__arrow" 
-              xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="-1 -1 20 20"><g fill="none" fill-rule="evenodd"><circle stroke-width=".74" cx="9" cy="9" r="9"/><path d="M9.43 3.27l5.1 5.37v.5l-5.1 5.38-.48-.5 3.66-4.6H3.3V8.37h9.34L9 3.77"/></g></svg>
+              <svg
+                class="link-with-arrow__arrow"
+                xmlns="http://www.w3.org/2000/svg"
+                width="18"
+                height="18"
+                viewBox="-1 -1 20 20"
+              >
+                <g fill="none" fill-rule="evenodd">
+                  <circle stroke-width=".74" cx="9" cy="9" r="9" />
+                  <path
+                    d="M9.43 3.27l5.1 5.37v.5l-5.1 5.38-.48-.5 3.66-4.6H3.3V8.37h9.34L9 3.77"
+                  />
+                </g>
+              </svg>
             </a>
-
           </p>
         </section>
 
-        <div class="custom-email">
-            <iframe
-              src="https://www.theguardian.com/email/form/plaintone/3039"
-              height="95px"
-              width="100%"
-              scrolling="no"
-              frameborder="0"
-              seamless
-              class="iframed--overflow-hidden js-email-sub__iframe js-email-sub__iframe--article"
-              data-form-success-desc=""
-            >
-            </iframe>
+        <section class="custom-email">
+          <iframe
+            src="https://www.theguardian.com/email/form/plaintone/3039"
+            height="95px"
+            width="100%"
+            scrolling="no"
+            frameborder="0"
+            seamless
+            class="iframed--overflow-hidden js-email-sub__iframe js-email-sub__iframe--article"
+            data-form-success-desc=""
+          >
+          </iframe>
 
-            <div class="email-signup__aside-text">
-              <span>No spam ever. Unsubscribe in one click.</span>
-              <span class="email-signup__aside-text__frequency">
-                <span class="inline-clock inline-icon" aria-label="frequency" role="img">
-                  <svg width="11" height="11" viewBox="0 0 11 11">
-                    <path
-                      d="M5.4 0c-3 0-5.4 2.4-5.4 5.4s2.4 5.4 5.4 5.4 5.4-2.4 5.4-5.4-2.4-5.4-5.4-5.4zm3 6.8h-3.7v-5.1h.7l.6 3.7 2.4.6v.8z"
-                    />
-                  </svg>
-                </span>
-                Every Sun
+          <div class="custom-email__aside-text">
+            <span>No spam ever. Unsubscribe in one click.</span>
+            <span class="custom-email__aside-text__frequency">
+              <span
+                class="inline-clock inline-icon"
+                aria-label="frequency"
+                role="img"
+              >
+                <svg width="11" height="11" viewBox="0 0 11 11">
+                  <path
+                    d="M5.4 0c-3 0-5.4 2.4-5.4 5.4s2.4 5.4 5.4 5.4 5.4-2.4 5.4-5.4-2.4-5.4-5.4-5.4zm3 6.8h-3.7v-5.1h.7l.6 3.7 2.4.6v.8z"
+                  />
+                </svg>
               </span>
-            </div>
-        </div>
+              Every Sun
+            </span>
+          </div>
+        </section>
         <!-- end of email-signup-main div -->
       </div>
     </div>
     <!-- end of gs-container -->
-  </div>
+  </article>
   <!-- end of content email-signup-main -->
-
-  <div class="content">
-    <div class="gs-container">
-      <div class="content__main-column">
-        <div class="email-signup-sample"></div>
-      </div>
-    </div>
-  </div>
 </div>

--- a/bookmarks/atoms/default/server/templates/main.html
+++ b/bookmarks/atoms/default/server/templates/main.html
@@ -290,9 +290,8 @@
         </section>
 
         <div class="custom-email">
-          <div class="email-signup email-signup__lozenge">
             <iframe
-              src="https://www.theguardian.com/email/form/plain/3039"
+              src="https://www.theguardian.com/email/form/plaintone/3039"
               height="60px"
               width="100%"
               scrolling="no"
@@ -316,7 +315,6 @@
                 Every Sun
               </span>
             </div>
-          </div>
         </div>
         <!-- end of email-signup-main div -->
       </div>

--- a/bookmarks/atoms/default/server/templates/main.html
+++ b/bookmarks/atoms/default/server/templates/main.html
@@ -1,5 +1,5 @@
 <div class="interactive-wrapper">
-  <div class="illustration-container">
+  <div class="illustration-container" role="img" aria-describedby="bookmarks-interactive-illustration-description">
     <div class="inline-custom__png"></div>
     <div class="inline-svg">
       <svg
@@ -9,6 +9,7 @@
         height="480"
         viewBox="0 0 3004 480"
       >
+      <desc id="bookmarks-interactive-illustration-description">A person reading on a comfortable chair while the book transports their imagination to a distant planet populated with various fictional characters.</desc>
         <g id="Shooting_Stars">
           <g id="shooting-star-4">
             <linearGradient
@@ -248,10 +249,11 @@
   <div class="content email-signup-main">
     <div class="gs-container">
       <div class="content__main-column main__column--horizontal-bar">
-        <header class="email-signup-header">
-          <span class="u-h">Bookmarks</span>
-          <span class="email-signup-header__heading">
+        <section class="email-signup-header">
+          <span class="email-signup-header__heading" aria-label="Bookmarks">
             <svg
+              role="img"
+              aria-hidden="true"
               width="405"
               height="78"
               viewBox="0 0 405 78"
@@ -285,7 +287,7 @@
             </a>
 
           </p>
-        </header>
+        </section>
 
         <div class="custom-email">
           <div class="email-signup email-signup__lozenge">


### PR DESCRIPTION
## What does this change?
Adjust the bookmarks sign up interactive to look right rendered through DCR, instead of being a pressed page. Uses a white inner background for the email signup section so the recently added captcha text is visible.

The animated rocket jet works again (didn't track down the reason, but on the live site there the booster flame doesn't show).

## Screenshots

| before | after |
|---|---|
| ![www theguardian com_info_ng-interactive_2017_mar_30_sign-up-for-the-bookmarks-email (1)](https://user-images.githubusercontent.com/30567854/156781985-04bab4e8-b9f9-408b-93ba-6f517a6ed251.png) | ![localhost_8000_default_dcr_immersive html (1)](https://user-images.githubusercontent.com/30567854/156782882-0b59de98-cb83-4361-ac73-75447c206ca0.png)
|








## Request for comment

<!-- mention someone here to review your changes -->
